### PR TITLE
Restore support for reusing serial ports

### DIFF
--- a/alicat/mock.py
+++ b/alicat/mock.py
@@ -23,6 +23,7 @@ class FlowController(RealFlowController):
     def __init__(self, address: str, unit: str = 'A', *args: Any, **kwargs: Any) -> None:
         """Initialize the device client."""
         self.hw = AsyncClientMock()
+        self.hw.address = address
         self.open = True
         self.control_point: str = choice(['flow', 'pressure'])
         self.state: dict[str, str | float] = {


### PR DESCRIPTION
Closes #30

Need to test:
 - [x] with mocked connections
 - [x] with multiple serial connections
 - [x] with a single serial connection
 - [ ] with multiple TCP connections
 - [ ] with a single TCP connection

