### PR TITLE
Fix: nonblocking serial

### DIFF
--- a/alicat/util.py
+++ b/alicat/util.py
@@ -211,12 +211,12 @@ class SerialClient(Client):
                                'parity': parity,
                                'timeout': timeout,
                                'loop': loop}
-        self.reader, self.writer = loop.run_until_complete(
+        self.reader, self.writer = asyncio.run_coroutine_threadsafe(
             serial_asyncio_fast.open_serial_connection(
                 url = self.address, 
                 **self.serial_details
-            )
-        )
+            ), loop = loop
+        ).result()
 
     async def _read(self, length: int) -> str:
         """Read a fixed number of bytes from the device."""

--- a/alicat/util.py
+++ b/alicat/util.py
@@ -212,7 +212,10 @@ class SerialClient(Client):
                                'timeout': timeout,
                                'loop': loop}
         self.reader, self.writer = loop.run_until_complete(
-            serial_asyncio_fast.open_serial_connection(self.address, **self.serial_details) # type: ignore [arg-type]
+            serial_asyncio_fast.open_serial_connection(
+                url = self.address, 
+                **self.serial_details
+            )
         )
 
     async def _read(self, length: int) -> str:

--- a/alicat/util.py
+++ b/alicat/util.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from abc import ABC, abstractmethod
 from typing import Any
+
+from abc import ABC, abstractmethod
 
 import serial
 import serial_asyncio_fast
@@ -20,6 +21,18 @@ logger = logging.getLogger('alicat')
 class Client(ABC):
     """Serial or TCP client."""
 
+    address: str
+    open: bool
+    timeout: float
+    timeouts: int
+    max_timeouts: int
+    reconnecting: bool
+    eol: bytes
+    lock: asyncio.Lock
+
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+
     def __init__(self, timeout: float):
         """Initialize common attributes."""
         self.address = ''
@@ -27,23 +40,42 @@ class Client(ABC):
         self.timeout = timeout
         self.timeouts = 0
         self.max_timeouts = 10
-        self.connection: dict[str, Any] = {}
         self.reconnecting = False
         self.eol = b'\r'
         self.lock = asyncio.Lock()
 
-    @abstractmethod
-    async def _write(self, message: str) -> None:
-        """Write a message to the device."""
-        ...
+    async def __aenter__(self) -> Client:
+        """Provide async entrance to context manager.
 
-    @abstractmethod
+        Contrasting synchronous access, this will connect on initialization.
+        """
+        await self._handle_connection()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """Provide async exit to context manager."""
+        await self.close()
+
+    async def _write(self, message: str) -> None:
+        """Write a command and do not expect a response.
+
+        As industrial devices are commonly unplugged, this has been expanded to
+        handle recovering from disconnects.
+        """
+        await self._handle_connection()
+        self.writer.write(message.encode() + self.eol)
+
     async def _read(self, length: int) -> str:
         """Read a fixed number of bytes from the device."""
+        await self._handle_connection()
+        response = await self.reader.read(length)
+        return response.decode().strip()
 
-    @abstractmethod
     async def _readline(self) -> str:
         """Read until a LF terminator."""
+        await self._handle_connection()
+        response = await self.reader.readuntil(self.eol)
+        return response.decode().strip().replace('\x00', '')
 
     async def _write_and_read(self, command: str) -> str | None:
         """Write a command and read a response.
@@ -76,7 +108,8 @@ class Client(ABC):
         """Manage communication, including timeouts and logging."""
         try:
             await self._write(command)
-            result = await self._readline()
+            future = self._readline()
+            result = await asyncio.wait_for(future, timeout=0.75)
             self.timeouts = 0
             return result
         except (asyncio.TimeoutError, TypeError, OSError):
@@ -86,71 +119,6 @@ class Client(ABC):
                              f'{self.timeouts} times.')
                 await self.close()
             return None
-
-    @abstractmethod
-    async def _handle_connection(self) -> None:
-        pass
-
-    @abstractmethod
-    async def close(self) -> None:
-        """Close the connection."""
-        pass
-
-
-class TcpClient(Client):
-    """A generic reconnecting asyncio TCP client.
-
-    This base functionality can be used by any industrial control device
-    communicating over TCP.
-    """
-
-    def __init__(self, address: str, timeout: float=1.0):
-        """Communicator using a TCP/IP<=>serial gateway."""
-        super().__init__(timeout)
-        try:
-            self.address, self.port = address.split(':')
-        except ValueError as e:
-            raise ValueError('address must be hostname:port') from e
-
-    async def __aenter__(self) -> Client:
-        """Provide async entrance to context manager.
-
-        Contrasting synchronous access, this will connect on initialization.
-        """
-        await self._handle_connection()
-        return self
-
-    async def __aexit__(self, *args: Any) -> None:
-        """Provide async exit to context manager."""
-        await self.close()
-
-    async def _connect(self) -> None:
-        """Asynchronously open a TCP connection with the server."""
-        await self.close()
-        reader, writer = await asyncio.open_connection(self.address, self.port)
-        self.connection = {'reader': reader, 'writer': writer}
-        self.open = True
-
-    async def _read(self, length: int) -> str:
-        """Read a fixed number of bytes from the device."""
-        await self._handle_connection()
-        response = await self.connection['reader'].read(length)
-        return response.decode().strip()
-
-    async def _readline(self) -> str:
-        """Read until a line terminator."""
-        await self._handle_connection()
-        response = await self.connection['reader'].readuntil(self.eol)
-        return response.decode().strip().replace('\x00', '')
-
-    async def _write(self, command: str) -> None:
-        """Write a command and do not expect a response.
-
-        As industrial devices are commonly unplugged, this has been expanded to
-        handle recovering from disconnects.
-        """
-        await self._handle_connection()
-        self.connection['writer'].write(command.encode() + self.eol)
 
     async def _handle_connection(self) -> None:
         """Automatically maintain TCP connection."""
@@ -164,80 +132,82 @@ class TcpClient(Client):
                 logger.error(f'Connecting to {self.address} timed out.')
             self.reconnecting = True
 
-    async def _handle_communication(self, command: str) -> str | None:
-        """Manage communication, including timeouts and logging."""
-        try:
-            await self._write(command)
-            future = self._readline()
-            result = await asyncio.wait_for(future, timeout=0.75)
-            self.timeouts = 0
-            return result
-        except (asyncio.TimeoutError, TypeError, OSError):
-            self.timeouts += 1
-            if self.timeouts == self.max_timeouts:
-                logger.error(f'Reading from {self.address} timed out '
-                             f'{self.timeouts} times.')
-                await self.close()
-            return None
-
     async def close(self) -> None:
-        """Close the TCP connection."""
+        """Close the connection."""
         if self.open:
-            self.connection['writer'].close()
-            await self.connection['writer'].wait_closed()
+            self.writer.close()
+            await self.writer.wait_closed()
         self.open = False
+
+    @abstractmethod
+    async def _connect(self) -> None:
+        ...    
+
+
+class TcpClient(Client):
+    """A generic reconnecting asyncio TCP client.
+
+    This base functionality can be used by any industrial control device
+    communicating over TCP.
+    """
+
+    port: str
+
+    def __init__(self, address: str, timeout: float = 1.0):
+        """Communicator using a TCP/IP<=>serial gateway."""
+        super().__init__(timeout)
+        try:
+            self.address, self.port = address.split(':')
+        except ValueError as e:
+            raise ValueError('address must be hostname:port') from e
+
+    async def _connect(self) -> None:
+        """Asynchronously open a TCP connection with the server."""
+        await self.close()
+        self.reader, self.writer = await asyncio.open_connection(self.address, self.port)
+        self.open = True
 
 
 class SerialClient(Client):
     """Client using a directly-connected RS232 serial device."""
 
-    reader: asyncio.StreamReader
-    writer: asyncio.StreamWriter
+    baudrate: int
+    bytesize: int
+    stopbits: int
+    parity: str
 
-    def __init__(self, address: str, baudrate: int=19200, timeout: float=.15,
+    def __init__(self, 
+                 address: str, 
+                 baudrate: int = 19200, 
+                 timeout: float = 0.15,
                  bytesize: int = serial.EIGHTBITS,
                  stopbits: int = serial.STOPBITS_ONE,
-                 parity: str = serial.PARITY_NONE,
-                 loop: asyncio.AbstractEventLoop | None = None):
-        """Initialize serial port."""
+                 parity: str = serial.PARITY_NONE):
         super().__init__(timeout)
+
         self.address = address
         assert isinstance(self.address, str)
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self.serial_details = {'baudrate': baudrate,
-                               'bytesize': bytesize,
-                               'stopbits': stopbits,
-                               'parity': parity,
-                               'timeout': timeout,
-                               'loop': loop}
-        self.reader, self.writer = asyncio.run_coroutine_threadsafe(
-            serial_asyncio_fast.open_serial_connection(
-                url = self.address, 
-                **self.serial_details
-            ), loop = loop
-        ).result()
 
-    async def _read(self, length: int) -> str:
-        """Read a fixed number of bytes from the device."""
-        return (await self.reader.read(length)).decode()
+        self.baudrate = baudrate
+        self.bytesize = bytesize
+        self.stopbits = stopbits
+        self.parity = parity
 
-    async def _readline(self) -> str:
-        """Read until a LF terminator."""
-        return (await self.reader.readline()).strip().decode().replace('\x00', '')
+    async def _connect(self) -> None:
+        """Asynchronously open a TCP connection with the server."""
+        await self.close()
 
-    async def _write(self, message: str) -> None:
-        """Write a message to the device."""
-        self.writer.write(message.encode() + self.eol)
-        # await self.writer.drain() # Previous impl didn't flush stream after writes
+        self.reader, self.writer = await serial_asyncio_fast.open_serial_connection(
+            url = self.address, 
+            baudrate = self.baudrate,
+            bytesize = self.bytesize,
+            stopbits = self.stopbits,
+            parity = self.parity,
+            timeout = self.timeout
+        )
 
-    async def close(self) -> None:
-        """Release resources."""
-        self.writer.close()
-        await self.writer.wait_closed()
-
-    async def _handle_connection(self) -> None:
         self.open = True
+
 
 def _is_float(msg: Any) -> bool:
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.8.0"
 description="Python driver for Alicat mass flow controllers."
 dependencies = [
   "pyserial",
+  "pyserial-asyncio-fast"
 ]
 authors = [
   {name = "Pat Fuller", email = "patrickfuller@gmail.com" },


### PR DESCRIPTION
Addresses #42 

I've decided to use the homelab fork of `pyserial-asyncio` to provide non-blocking serial IO, which allows for a refactor of the util `Client` classes to reduce a lot of redundancy.

Because of this slight refactor, it's important to review and test on your hardware.

Thanks again for the module!

