### PR TITLE
Restore compatibility with 3.9

### DIFF
--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -152,8 +152,7 @@ class FlowMeter:
         elif len(values) == 2 and len(self.keys) == 6:
             self.keys.insert(1, 'setpoint')
         return {k: (float(v) if _is_float(v) else v)
-                for k, v in zip(self.keys, values, strict=True)}  # type: ignore[call-overload]
-                                                                  # PEP618
+                for k, v in zip(self.keys, values)}
     async def set_gas(self, gas: str | int) -> None:
         """Set the gas type.
 
@@ -473,8 +472,7 @@ class FlowController(FlowMeter):
             pid_values.append(value_spl[3])
 
         return {k: (v if k == self.pid_keys[-1] else str(v))
-                for k, v in zip(self.pid_keys, pid_values, strict=True)}  # type: ignore[call-overload]
-                                                                          # PEP618
+                for k, v in zip(self.pid_keys, pid_values)}
 
     async def set_pid(self, p: int | None=None,
                             i: int | None=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",
 ]
+requires-python = ">= 3.9"
 
 [project.optional-dependencies]
 test = [
@@ -55,7 +56,7 @@ packages = ["alicat"]
 [tool.ruff]
 extend-exclude = ["venv*"]
 line-length = 120
-target-version = "py310"
+target-version = "py39"
 
 [tool.ruff.lint]
 ignore = [


### PR DESCRIPTION
Closes #47

Although I expect this code will also work in Python 3.8, I don't intend to support it - so add a restriction in `pyproject.toml`.

When we can drop 3.9 and bump the `ruff` target verison, it will warn about adding `strict=True` again.  Until then, the check isn't actually needed.
