### PR TITLE
Handle LCR series (liquid) not having gas or volumetric flowrate

### DIFF
--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -151,6 +151,9 @@ class FlowMeter:
             self.keys.insert(5, 'total flow')
         elif len(values) == 2 and len(self.keys) == 6:
             self.keys.insert(1, 'setpoint')
+        elif len(values) == 4 and len(self.keys) == 6:  # LCR (liquid)
+            del self.keys[-1]  # gas
+            del self.keys[2]  # volumetric flow
         return {k: (float(v) if _is_float(v) else v)
                 for k, v in zip(self.keys, values)}
     async def set_gas(self, gas: str | int) -> None:


### PR DESCRIPTION
See https://github.com/numat/alicat/issues/157

Thanks to @cwayman-celestica


> Here's the error I get when I connect to my LCR-2LPM-D
> 
> ```
> File "C:\path\to\.venv\Lib\site-packages\alicat\driver.py", line 158, in get
>     for k, v in zip(self.keys, values, strict=True)}  # type: ignore[call-overload]
>                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> ValueError: zip() argument 2 is shorter than argument 1
> ```
> 
> ![Image](https://github.com/user-attachments/assets/c9e24ff5-a815-4bf2-98d9-309a084de8f3)
> 
> ![Image](https://github.com/user-attachments/assets/32d36ef6-beac-407e-8d86-a48d9e9289ce)
> 
> Looks like there isn't a use case for 4 values and 6 keys returned. Added case here
> 
> ![Image](https://github.com/user-attachments/assets/d8533001-716c-4633-9f0e-59f1ef174e0c)
> 
> New to issues, how do I push this fix?

