### PR TITLE
Max ramp rate

### DIFF
--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -637,7 +637,6 @@ class FlowController(FlowMeter):
         if not line or self.unit not in line:
             raise OSError("Could not read max ramp.")
         values = line.split(' ')
-        print(values)
         if len(values) != 5:
             raise OSError("Could not read max ramp.")
         return {

--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -638,6 +638,6 @@ class FlowController(FlowMeter):
             raise OSError("Could not read max ramp.")
         values = line.split(' ')
         print(values)
-        if len(values) != 2:
+        if len(values) != 5:
             raise OSError("Could not read max ramp.")
         return float(values[1])

--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -637,6 +637,7 @@ class FlowController(FlowMeter):
         if not line or self.unit not in line:
             raise OSError("Could not read max ramp.")
         values = line.split(' ')
+        print(values)
         if len(values) != 2:
             raise OSError("Could not read max ramp.")
         return float(values[1])

--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -608,3 +608,35 @@ class FlowController(FlowMeter):
             'zero': values[2] == '1',
             'power': values[3] == '1',
         }
+
+    async def set_maxramp(self, max_ramp: float, unit_time: int) -> None:
+        """Set the maximum ramp rate (firmware 10v05).
+
+        Args:
+            max_ramp: The maximum ramp rate
+            unit_time: The units of the ramp rate
+                - 3: millisecond
+                - 4: second
+                - 5: minute
+                - 6: hour
+                - 7: day
+        """
+        command = f"{self.unit}SR {max_ramp:.2f} {unit_time}"
+        line = await self._write_and_read(command)
+        if not line or self.unit not in line:
+            raise OSError("Could not set max ramp.")
+
+    async def get_maxramp(self) -> float:
+        """Get the maximum ramp rate (firmware 10v05).
+
+        Returns:
+            max_ramp: The maximum ramp rate
+        """
+        command = f"{self.unit}SR"
+        line = await self._write_and_read(command)
+        if not line or self.unit not in line:
+            raise OSError("Could not read max ramp.")
+        values = line.split(' ')
+        if len(values) != 2:
+            raise OSError("Could not read max ramp.")
+        return float(values[1])

--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -626,7 +626,7 @@ class FlowController(FlowMeter):
         if not line or self.unit not in line:
             raise OSError("Could not set max ramp.")
 
-    async def get_maxramp(self) -> float:
+    async def get_maxramp(self) -> dict[str, float]:
         """Get the maximum ramp rate (firmware 10v05).
 
         Returns:
@@ -640,4 +640,7 @@ class FlowController(FlowMeter):
         print(values)
         if len(values) != 5:
             raise OSError("Could not read max ramp.")
-        return float(values[1])
+        return {
+            'max_ramp': float(values[1]),
+            'units': values[4],
+        }

--- a/alicat/mock.py
+++ b/alicat/mock.py
@@ -97,7 +97,10 @@ class FlowController(RealFlowController):
         """Set the maximum ramp rate."""
         self.max_ramp = max_ramp
 
-    async def get_maxramp(self) -> float:
+    async def get_maxramp(self) -> dict[str, float]:
         """Get the maximum ramp rate."""
-        return self.max_ramp
+        return {
+            'max_ramp': self.max_ramp,
+            'units': 'SLPM/s',
+        }
     

--- a/alicat/mock.py
+++ b/alicat/mock.py
@@ -42,6 +42,7 @@ class FlowController(RealFlowController):
         self.keys = ['pressure', 'temperature', 'volumetric_flow', 'mass_flow',
                      'setpoint', 'gas']
         self.firmware = '6v21.0-R22 Nov 30 2016,16:04:20'
+        self.max_ramp = 0.0
 
     async def get(self) -> dict[str, str | float]:
         """Return the full state."""
@@ -91,3 +92,12 @@ class FlowController(RealFlowController):
     async def set_ramp_config(self, config: dict[str, bool]) -> None:
         """Set ramp config."""
         self.ramp_config = config
+
+    async def set_maxramp(self, max_ramp: float, unit_time: int) -> None:
+        """Set the maximum ramp rate."""
+        self.max_ramp = max_ramp
+
+    async def get_maxramp(self) -> float:
+        """Get the maximum ramp rate."""
+        return self.max_ramp
+    

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -82,7 +82,8 @@ async def test_maxramp():
     """Confirm that setting/getting the maximum ramp rate works."""
     async with FlowController(ADDRESS) as device:
         max_ramp = round(uniform(0.01, 0.1), 2)
-        await device.set_maxramp(max_ramp, 3)
+        await device.set_maxramp(max_ramp, 4)
         result = await device.get_maxramp()
-        assert max_ramp == result
+        assert max_ramp == result['max_ramp']
+        assert 'SLPM/s' == result['units']
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -76,3 +76,13 @@ async def test_ramp_config(config):
         await device.set_ramp_config(config)
         result = await device.get_ramp_config()
         assert config == result
+
+
+async def test_maxramp():
+    """Confirm that setting/getting the maximum ramp rate works."""
+    async with FlowController(ADDRESS) as device:
+        max_ramp = round(uniform(0.01, 0.1), 2)
+        await device.set_maxramp(max_ramp, 3)
+        result = await device.get_maxramp()
+        assert max_ramp == result
+


### PR DESCRIPTION
Added Functionality for setting and getting the max ramp rate.
Sends the SR command as defined in the Alicat Serial Handbook

Uses the unit number definitions defined in the handbook.

Tested on controllers using 10V20-R24 firmware over RS232 serial.