### PR TITLE
Add pressure meters and controllers

### DIFF
--- a/alicat/__init__.py
+++ b/alicat/__init__.py
@@ -10,6 +10,8 @@ from alicat.driver import (  # noqa  # type: ignore
     FlowController,
     FlowMeter,
     MaxRampTimeUnit,
+    PressureController,
+    PressureMeter,
 )
 
 

--- a/alicat/__init__.py
+++ b/alicat/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from alicat.driver import (  # noqa  # type: ignore
     MAX_RAMP_TIME_UNITS,
+    AlicatDevice,
     FlowController,
     FlowMeter,
     MaxRampTimeUnit,

--- a/alicat/driver.py
+++ b/alicat/driver.py
@@ -704,3 +704,48 @@ class FlowController(FlowMeter, ControllerMixin):
         if value != reg:
             raise OSError("Could not set control point.")
         self.control_point = point
+
+
+class PressureMeter(AlicatDevice):
+    """Python driver for Alicat Pressure Meters.
+
+    These devices measure pressure only (no flow, no control).
+    """
+
+    def __init__(self, address: str = '/dev/ttyUSB0', unit: str = 'A',
+                 **kwargs: Any) -> None:
+        """Connect this driver with the appropriate USB / serial port.
+
+        Args:
+            address: The serial port or TCP address:port. Default '/dev/ttyUSB0'.
+            unit: The Alicat-specified unit ID, A-Z. Default 'A'.
+        """
+        super().__init__(address, unit, **kwargs)
+        self.keys = ['pressure']
+
+
+class PressureController(PressureMeter, ControllerMixin):
+    """Python driver for Alicat Pressure Controllers (PC-series).
+
+    These devices control pressure using an internal valve.
+    """
+
+    def __init__(self, address: str = '/dev/ttyUSB0', unit: str = 'A',
+                 **kwargs: Any) -> None:
+        """Connect this driver with the appropriate USB / serial port.
+
+        Args:
+            address: The serial port or TCP address:port. Default '/dev/ttyUSB0'.
+            unit: The Alicat-specified unit ID, A-Z. Default 'A'.
+        """
+        super().__init__(address, unit, **kwargs)
+        self.keys = ['pressure', 'setpoint']
+
+    async def set_pressure(self, pressure: float) -> None:
+        """Set the target pressure.
+
+        Args:
+            pressure: The target pressure, in units specified at time of
+                purchase. Likely in psia.
+        """
+        await self._set_setpoint(pressure)

--- a/alicat/mock.py
+++ b/alicat/mock.py
@@ -1,23 +1,59 @@
-"""Mock for offline testing of `FlowController`s."""
+"""Mock for offline testing of Alicat devices."""
 from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Callable
 from random import choice, random
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
 
 from .driver import CONTROL_POINTS, GASES, MAX_RAMP_TIME_UNITS, MaxRampTimeUnit
 from .util import Client as RealClient
 
+DeviceType = Literal['flow_meter', 'flow_controller', 'pressure_meter', 'pressure_controller']
+
+# Keys for each device type, matching the driver classes
+DEVICE_KEYS: dict[DeviceType, list[str]] = {
+    'pressure_meter': ['pressure'],
+    'pressure_controller': ['pressure', 'setpoint'],
+    'flow_meter': ['pressure', 'temperature', 'volumetric_flow', 'mass_flow', 'gas'],
+    'flow_controller': ['pressure', 'temperature', 'volumetric_flow', 'mass_flow', 'setpoint', 'gas'],
+}
+
+# Factory functions to generate default values for each state key
+STATE_FACTORIES: dict[str, Callable[[], str | float]] = {
+    'pressure': lambda: random() * 50.0,
+    'temperature': lambda: random() * 50.0,
+    'volumetric_flow': lambda: 0.0,
+    'mass_flow': lambda: 10 * (0.95 + 0.1 * random()),
+    'gas': lambda: 'N2',
+    'setpoint': lambda: 10.0,
+    'total flow': lambda: 0.0,  # Note: space to match driver key name
+}
+
 
 class Client(RealClient):
-    """Mock the alicat communication client."""
+    """Mock the alicat communication client for all device types.
 
-    def __init__(self, address: str) -> None:
+    Args:
+        address: Serial port address (ignored in mock).
+        device_type: Type of device to simulate:
+            - 'flow_meter': FlowMeter (5 values: pressure, temp, vol_flow, mass_flow, gas)
+            - 'flow_controller': FlowController (6 values: above + setpoint)
+            - 'pressure_meter': PressureMeter (1 value: pressure)
+            - 'pressure_controller': PressureController (2 values: pressure, setpoint)
+    """
+
+    def __init__(self, address: str, device_type: DeviceType = 'flow_controller') -> None:
+        """Initialize mock client."""
         super().__init__(timeout=0.01)
         _ = address
+        self.device_type = device_type
+        self.keys = list(DEVICE_KEYS[device_type])  # copy to allow modification
+
         self.writer = MagicMock(spec=asyncio.StreamWriter)
-        self.writer.write.side_effect=self._handle_write
+        self.writer.write.side_effect = self._handle_write
         self.reader = AsyncMock(spec=asyncio.StreamReader)
         self.reader.read.return_value = self.eol
         self.reader.readuntil.side_effect = self._handle_read
@@ -25,39 +61,49 @@ class Client(RealClient):
         self.open = True
         self._next_reply = ''
 
-        self.open = True
-        self.control_point: str = choice(list(CONTROL_POINTS))
+        # Initialize state from keys - DEVICE_KEYS is the single source of truth
         self.state: dict[str, str | float] = {
-            'setpoint': 10,
-            'gas': 'N2',
-            'mass_flow': 10 * (0.95 + 0.1 * random()),
-            'pressure': random() * 50.0,
-            'temperature': random() * 50.0,
-            'total_flow': 0.0,
-            'volumetric_flow': 0.0,
+            key: STATE_FACTORIES[key]() for key in self.keys
         }
-        self.ramp_config = { 'up': False, 'down': False, 'zero': False, 'power': False }
+
+        # Flow controllers have control_point
+        if device_type == 'flow_controller':
+            self.control_point: str = choice(list(CONTROL_POINTS))
+
+        self.ramp_config = {'up': False, 'down': False, 'zero': False, 'power': False}
         self.button_lock: bool = False
-        self.keys = ['pressure', 'temperature', 'volumetric_flow', 'mass_flow',
-                     'setpoint', 'gas']
         self.firmware = '6v21.0-R22 Nov 30 2016,16:04:20'
-        self.max_ramp_time_unit : MaxRampTimeUnit
+        self.max_ramp_time_unit: MaxRampTimeUnit = 's'
+        self.max_ramp: float = 0.0
 
     async def _handle_connection(self) -> None:
+        """Mock connection handler."""
         pass
 
+    def _format_value(self, key: str) -> str:
+        """Format a single value for the data frame."""
+        value = self.state[key]
+        if key == 'gas':
+            return f"{value:<7}"
+        elif key == 'setpoint':
+            return f"{value:07.2f}"
+        else:
+            # Numeric values with sign
+            return f"{value:+07.2f}"
+
     def _create_dataframe(self) -> str:
-        """Generate a typical 'dataframe' with current operating conditions."""
-        return (
-            f"{self.unit} "
-            f"{self.state['pressure']:+07.2f} "
-            f"{self.state['temperature']:+07.2f} "
-            f"{self.state['volumetric_flow']:+07.2f} "
-            f"{self.state['mass_flow']:+07.2f} "
-            f"{self.state['setpoint']:07.2f} "
-            f"{self.state['gas']:<7} "
-            f"{'LCK' if self.button_lock else ''}"
-        )
+        """Generate a typical 'dataframe' with current operating conditions.
+
+        Uses self.keys to determine which fields to include, matching
+        how the driver classes work.
+        """
+        parts = [self.unit]
+        for key in self.keys:
+            parts.append(self._format_value(key))
+        if self.button_lock:
+            parts.append('LCK')
+        return ' '.join(parts)
+
     def _create_ramp_response(self) -> str:
         """Generate a response to setting or getting the ramp config."""
         config = self.ramp_config
@@ -75,8 +121,16 @@ class Client(RealClient):
                 f" {MAX_RAMP_TIME_UNITS[self.max_ramp_time_unit]}"
                 f" SLPM/{self.max_ramp_time_unit}")
 
+    def _is_flow_device(self) -> bool:
+        """Check if this is a flow device (meter or controller)."""
+        return 'gas' in self.keys
+
+    def _is_controller(self) -> bool:
+        """Check if this is a controller (has setpoint)."""
+        return 'setpoint' in self.keys
+
     def _handle_write(self, data: bytes) -> None:
-        """Act on writes sent to the mock client, updating internal state and setting self._next_reply if necessary."""
+        """Act on writes sent to the mock client, updating internal state."""
         msg = data.decode().strip()
         self.unit = msg[0]
 
@@ -89,12 +143,11 @@ class Client(RealClient):
         elif msg == '$$U':  # unlock
             self.button_lock = False
             self._next_reply = self._create_dataframe()
-        elif 'W122=' in msg:  # set control point
-            cp = int(msg[5:])
-            self.control_point = next(p for p, i in CONTROL_POINTS.items() if cp == i)
-            self._next_reply = f"{self.unit}   122 = {cp}"
-        elif msg == 'R122':  # read control point
-            self._next_reply = f"{self.unit}   122 = {CONTROL_POINTS[self.control_point]}"
+        elif msg == 'VE':  # get firmware
+            self._next_reply = self.firmware
+        elif msg == '$$PC':  # tare pressure
+            self.state['pressure'] = 0
+            self._next_reply = self._create_dataframe()
         elif msg == 'LSRC':  # get ramp config
             self._next_reply = self._create_ramp_response()
         elif 'LSRC' in msg:  # set ramp config
@@ -112,27 +165,32 @@ class Client(RealClient):
             values = msg.split()
             self.max_ramp = float(values[1])
             unit_time_int = int(values[2])
-            self.max_ramp_time_unit = next(key for key, val in MAX_RAMP_TIME_UNITS.items() if val == unit_time_int)
+            self.max_ramp_time_unit = next(
+                key for key, val in MAX_RAMP_TIME_UNITS.items() if val == unit_time_int
+            )
             self._next_reply = self._create_max_ramp_response()
-        elif msg[0] == 'S':  # set setpoint
+        elif msg[0] == 'S' and self._is_controller():  # set setpoint (controllers only)
             self.state['setpoint'] = float(msg[1:])
             self._next_reply = self._create_dataframe()
-        elif msg[0:6] == '$$W46=':  # set gas via reg46
+        # Flow controller only: control point commands
+        elif self.device_type == 'flow_controller' and 'W122=' in msg:
+            cp = int(msg[5:])
+            self.control_point = next(p for p, i in CONTROL_POINTS.items() if cp == i)
+            self._next_reply = f"{self.unit}   122 = {cp}"
+        elif self.device_type == 'flow_controller' and msg == 'R122':
+            self._next_reply = f"{self.unit}   122 = {CONTROL_POINTS[self.control_point]}"
+        # Flow device (meter or controller): gas and flow commands
+        elif self._is_flow_device() and msg[0:6] == '$$W46=':  # set gas via reg46
             gas = msg[6:]
             self._next_reply = f"{self.unit}   046 = {gas}"
             with contextlib.suppress(ValueError):
                 gas = GASES[int(gas)]
             self.state['gas'] = gas
-        elif msg == '$$R46':  # read gas via reg46
-            gas_index = GASES.index(self.state['gas'])  # type: ignore
+        elif self._is_flow_device() and msg == '$$R46':  # read gas via reg46
+            gas_index = GASES.index(self.state['gas'])  # type: ignore[arg-type]
             reg46_value = gas_index & 0x1FF  # encode gas number in low 9 bits
             self._next_reply = f"{self.unit}   046 = {reg46_value}"
-        elif msg == 'VE':  # get firmware
-            self._next_reply = self.firmware
-        elif msg == '$$PC':
-            self.state['pressure'] = 0
-            self._next_reply = self._create_dataframe()
-        elif msg == '$$V':
+        elif self._is_flow_device() and msg == '$$V':  # tare volumetric flow
             self.state['volumetric_flow'] = 0
             self._next_reply = self._create_dataframe()
         else:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -108,7 +108,7 @@ async def test_set_gas_invalid(device):
 
 
 @pytest.mark.parametrize('device', FLOW_DEVICES, indirect=True)
-@pytest.mark.parametrize('gas_name,gas_num', [('Air', 0), ('H2', 6)])
+@pytest.mark.parametrize(('gas_name','gas_num'), [('Air', 0), ('H2', 6)])
 async def test_set_gas_by_number(device, gas_name, gas_num):
     """Confirm that setting standard gases by number works on flow devices."""
     async with device(ADDRESS) as d:
@@ -199,7 +199,7 @@ async def test_control_point(device, control_point):
 
 @pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
 @pytest.mark.parametrize('unit', ['A', 'B'])
-def test_driver_cli(device, capsys, unit):
+def test_driver_cli(device, capsys, unit): # noqa: ARG001
     """Confirm the commandline interface works with different unit IDs."""
     command_line([ADDRESS, '--unit', unit])
     captured = capsys.readouterr()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -5,70 +5,205 @@ from unittest import mock
 import pytest
 
 from alicat import command_line
-from alicat.driver import FlowController
+from alicat.driver import AlicatDevice, FlowController, FlowMeter, PressureController, PressureMeter
 from alicat.mock import Client
 
 ADDRESS = '/dev/ttyUSB0'
 
-@pytest.fixture(autouse=True)
-def patch_serial_client():
-    """Replace the serial client with our mock."""
-    with mock.patch('alicat.driver.SerialClient', Client):
-        yield
+# Mapping from device_type to driver class
+DEVICE_CLASSES = {
+    'flow_meter': FlowMeter,
+    'flow_controller': FlowController,
+    'pressure_meter': PressureMeter,
+    'pressure_controller': PressureController,
+}
 
+FLOW_DEVICES = ['flow_meter', 'flow_controller']
+PRESSURE_DEVICES = ['pressure_meter', 'pressure_controller']
+CONTROLLERS = ['flow_controller', 'pressure_controller']
+ALL_DEVICES = list(DEVICE_CLASSES.keys())
+
+
+@pytest.fixture
+def device(request):
+    """Parameterized fixture that sets up mock client and yields device class.
+
+    Usage:
+        @pytest.mark.parametrize('device', ['flow_controller', 'pressure_meter'], indirect=True)
+        async def test_something(device):
+            async with device(ADDRESS) as d:
+                ...
+    """
+    device_type = request.param
+    AlicatDevice.open_ports.clear()
+
+    def make_client(address, **kwargs):
+        return Client(address, device_type=device_type, **kwargs)
+
+    with mock.patch('alicat.driver.SerialClient', make_client):
+        yield DEVICE_CLASSES[device_type]
+    AlicatDevice.open_ports.clear()
+
+
+# =============================================================================
+# Tests for ALL devices
+# =============================================================================
+
+@pytest.mark.parametrize('device', ALL_DEVICES, indirect=True)
+async def test_lock_unlock(device):
+    """Confirm that locking/unlocking the buttons works on all devices."""
+    async with device(ADDRESS) as d:
+        await d.lock()
+        assert await d.is_locked()
+        await d.unlock()
+        assert not await d.is_locked()
+
+
+@pytest.mark.parametrize('device', ALL_DEVICES, indirect=True)
+async def test_tare_pressure(device):
+    """Confirm taring the pressure works on all devices."""
+    async with device(ADDRESS) as d:
+        await d.tare_pressure()
+        result = await d.get()
+        assert result['pressure'] == 0.0
+
+
+@pytest.mark.parametrize('device', ALL_DEVICES, indirect=True)
+async def test_get_firmware(device):
+    """Confirm the firmware version can be read from all devices."""
+    async with device(ADDRESS) as d:
+        result = await d.get_firmware()
+        assert 'v' in result or 'GP' in result
+
+
+# =============================================================================
+# Tests for FLOW devices (meter and controller)
+# =============================================================================
+
+@pytest.mark.parametrize('device', FLOW_DEVICES, indirect=True)
+async def test_tare_flow(device):
+    """Confirm taring the flow works on flow devices."""
+    async with device(ADDRESS) as d:
+        await d.tare_volumetric()
+        result = await d.get()
+        assert result['volumetric_flow'] == 0.0
+
+
+@pytest.mark.parametrize('device', FLOW_DEVICES, indirect=True)
+@pytest.mark.parametrize('gas', ['Air', 'H2'])
+async def test_set_gas_by_name(device, gas):
+    """Confirm that setting standard gases by name works on flow devices."""
+    async with device(ADDRESS) as d:
+        await d.set_gas(gas)
+        result = await d.get()
+        assert gas == result['gas']
+
+
+@pytest.mark.parametrize('device', FLOW_DEVICES, indirect=True)
+async def test_set_gas_invalid(device):
+    """Confirm that setting an invalid gas raises an error."""
+    async with device(ADDRESS) as d:
+        with pytest.raises(ValueError, match='not supported'):
+            await d.set_gas('methylacetylene-propadiene propane')
+
+
+@pytest.mark.parametrize('device', FLOW_DEVICES, indirect=True)
+@pytest.mark.parametrize('gas_name,gas_num', [('Air', 0), ('H2', 6)])
+async def test_set_gas_by_number(device, gas_name, gas_num):
+    """Confirm that setting standard gases by number works on flow devices."""
+    async with device(ADDRESS) as d:
+        await d.set_gas(gas_num)
+        result = await d.get()
+        assert gas_name == result['gas']
+
+
+# =============================================================================
+# Tests for CONTROLLERS (flow and pressure)
+# =============================================================================
+
+@pytest.mark.parametrize('device', CONTROLLERS, indirect=True)
+@pytest.mark.parametrize('config', [
+    {'up': True, 'down': False, 'zero': True, 'power': False},
+    {'up': True, 'down': True, 'zero': False, 'power': True},
+    {'up': False, 'down': False, 'zero': False, 'power': False},
+])
+async def test_ramp_config(device, config):
+    """Confirm changing the ramping configuration works on controllers."""
+    async with device(ADDRESS) as d:
+        await d.set_ramp_config(config)
+        result = await d.get_ramp_config()
+        assert config == result
+
+
+@pytest.mark.parametrize('device', CONTROLLERS, indirect=True)
+@pytest.mark.parametrize('unit_time', ['ms', 's', 'm', 'h', 'd'])
+async def test_maxramp(device, unit_time):
+    """Confirm that setting/getting the maximum ramp rate works on controllers."""
+    async with device(ADDRESS) as d:
+        max_ramp = round(uniform(0.01, 0.1), 2)
+        await d.set_maxramp(max_ramp, unit_time)
+        result = await d.get_maxramp()
+        assert max_ramp == result['max_ramp']
+        assert result['units'] == f'SLPM/{unit_time}'  # fixme make units dynamic
+
+
+# =============================================================================
+# Tests specific to FlowController
+# =============================================================================
+
+@pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
+async def test_flow_controller_get_fields(device):
+    """Confirm that FlowController.get() returns expected keys."""
+    async with device(ADDRESS) as d:
+        result = await d.get()
+        assert 'pressure' in result
+        assert 'temperature' in result
+        assert 'volumetric_flow' in result
+        assert 'mass_flow' in result
+        assert 'setpoint' in result
+        assert 'gas' in result
+        assert 'control_point' in result
+        assert 'status' in result
+        # 6 data fields + control_point + status = 8
+        assert len(result) == 8
+
+
+@pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
+async def test_flow_controller_is_connected(device):
+    """Confirm that connection status works for flow controller."""
+    async with device(ADDRESS) as d:
+        assert await d.is_connected(ADDRESS)
+        assert not await d.is_connected('bad_address')
+
+
+@pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
+async def test_flow_setpoint_roundtrip(device):
+    """Confirm that setting/getting flowrates works."""
+    async with device(ADDRESS) as d:
+        flow_sp = round(uniform(0.01, 0.1), 2)
+        await d.set_flow_rate(flowrate=flow_sp)
+        result = await d.get()
+        assert flow_sp == result['setpoint']
+
+
+@pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
+@pytest.mark.parametrize('control_point',
+    ['mass flow', 'vol flow', 'abs pressure', 'gauge pressure', 'diff pressure'])
+async def test_control_point(device, control_point):
+    """Confirm changing the control point works."""
+    async with device(ADDRESS) as d:
+        await d._set_control_point(control_point)
+        result = await d._get_control_point()
+        assert control_point == result
+
+
+@pytest.mark.parametrize('device', ['flow_controller'], indirect=True)
 @pytest.mark.parametrize('unit', ['A', 'B'])
-def test_driver_cli(capsys, unit):
+def test_driver_cli(device, capsys, unit):
     """Confirm the commandline interface works with different unit IDs."""
     command_line([ADDRESS, '--unit', unit])
     captured = capsys.readouterr()
     assert ("mass_flow" in captured.out)
-
-
-@pytest.mark.parametrize('cls', [FlowController])  # Fixme: fix FlowMeter
-async def test_is_connected(cls):
-    """Confirm that connection status works."""
-    async with cls(ADDRESS) as device:
-        assert await device.is_connected(ADDRESS)
-        assert not await device.is_connected('bad_address')
-
-
-async def test_flow_setpoint_roundtrip():
-    """Confirm that setting/getting flowrates works."""
-    async with FlowController(ADDRESS) as device:
-        flow_sp = round(uniform(0.01, 0.1), 2)
-        await device.set_flow_rate(flowrate=flow_sp)
-        # assert flow_sp == await device.get_flow_rate()
-        result = await device.get()
-        assert flow_sp == result['setpoint']
-
-
-async def test_lock_unlock():
-    """Confirm that locking/unlocking the buttons works."""
-    async with FlowController(ADDRESS) as device:
-        await device.lock()
-        assert await device.is_locked()
-        await device.unlock()
-        assert not await device.is_locked()
-
-
-@pytest.mark.parametrize('gas', ['Air', 'H2'])
-async def test_set_standard_gas_name(gas):
-    """Confirm that setting standard gases by name works."""
-    async with FlowController(ADDRESS) as device:
-        await device.set_gas(gas)
-        result = await device.get()
-        assert gas == result['gas']
-        with pytest.raises(ValueError, match='not supported'):
-            await device.set_gas('methylacetylene-propadiene propane')
-
-
-@pytest.mark.parametrize('gas', [('Air', 0), ('H2', 6)])
-async def test_set_standard_gas_number(gas):
-    """Confirm that setting standard gases by number works."""
-    async with FlowController(ADDRESS) as device:
-        await device.set_gas(gas[1])
-        result = await device.get()
-        assert gas[0] == result['gas']
 
 
 @pytest.mark.skip
@@ -77,56 +212,62 @@ async def test_create_gas_mix():
     pass
 
 
-async def test_tare_pressure():
-    """Confirm taring the absolute pressure works."""
-    async with FlowController(ADDRESS) as device:
-        await device.tare_pressure()
-        result = await device.get()
-        assert result['pressure'] == 0.0
+# =============================================================================
+# Tests specific to FlowMeter
+# =============================================================================
+
+@pytest.mark.parametrize('device', ['flow_meter'], indirect=True)
+async def test_flow_meter_get_fields(device):
+    """Confirm that FlowMeter.get() returns 5 data fields + status (no setpoint)."""
+    async with device(ADDRESS) as d:
+        result = await d.get()
+        assert 'pressure' in result
+        assert 'temperature' in result
+        assert 'volumetric_flow' in result
+        assert 'mass_flow' in result
+        assert 'gas' in result
+        assert 'status' in result
+        assert 'setpoint' not in result
+        # 5 data fields + status = 6
+        assert len(result) == 6
 
 
-async def test_tare_flow():
-    """Confirm taring the flow works."""
-    async with FlowController(ADDRESS) as device:
-        await device.tare_volumetric()
-        result = await device.get()
-        assert result['volumetric_flow'] == 0.0
+# =============================================================================
+# Tests specific to PressureController
+# =============================================================================
+
+@pytest.mark.parametrize('device', ['pressure_controller'], indirect=True)
+async def test_pressure_controller_get_fields(device):
+    """Confirm that PressureController.get() returns pressure, setpoint, and status."""
+    async with device(ADDRESS) as d:
+        result = await d.get()
+        assert 'pressure' in result
+        assert 'setpoint' in result
+        assert 'status' in result
+        # 2 data fields + status = 3
+        assert len(result) == 3
 
 
-async def test_get_firmware():
-    """Confirm the firmware version can be read."""
-    async with FlowController(ADDRESS) as device:
-        result = await device.get_firmware()
-        assert 'v' in result or 'GP' in result
+@pytest.mark.parametrize('device', ['pressure_controller'], indirect=True)
+async def test_pressure_controller_set_pressure(device):
+    """Confirm that setting pressure works."""
+    async with device(ADDRESS) as d:
+        pressure_sp = round(uniform(10.0, 20.0), 2)
+        await d.set_pressure(pressure_sp)
+        result = await d.get()
+        assert result['setpoint'] == pressure_sp
 
 
-@pytest.mark.parametrize('config', [
-    {'up': True, 'down': False, 'zero': True, 'power': False},
-    {'up': True, 'down': True, 'zero': False, 'power': True},
-    {'up': False, 'down': False, 'zero': False, 'power': False},
-    ])
-async def test_ramp_config(config):
-    """Confirm changing the ramping configuration works."""
-    async with FlowController(ADDRESS) as device:
-        await device.set_ramp_config(config)
-        result = await device.get_ramp_config()
-        assert config == result
+# =============================================================================
+# Tests specific to PressureMeter
+# =============================================================================
 
-@pytest.mark.parametrize('unit_time', ['ms', 's', 'm', 'h', 'd'])
-async def test_maxramp(unit_time):
-    """Confirm that setting/getting the maximum ramp rate works."""
-    async with FlowController(ADDRESS) as device:
-        max_ramp = round(uniform(0.01, 0.1), 2)
-        await device.set_maxramp(max_ramp, unit_time)
-        result = await device.get_maxramp()
-        assert max_ramp == result['max_ramp']
-        assert result['units'] == f'SLPM/{unit_time}'  # fixme make units dynamic
-
-@pytest.mark.parametrize('control_point',
-    ['mass flow', 'vol flow', 'abs pressure', 'gauge pressure', 'diff pressure'])
-async def test_control_point(control_point):
-    """Confirm changing the control point works."""
-    async with FlowController(ADDRESS) as device:
-        await device._set_control_point(control_point)
-        result = await device._get_control_point()
-        assert control_point == result
+@pytest.mark.parametrize('device', ['pressure_meter'], indirect=True)
+async def test_pressure_meter_get_fields(device):
+    """Confirm that PressureMeter.get() returns only pressure and status."""
+    async with device(ADDRESS) as d:
+        result = await d.get()
+        assert 'pressure' in result
+        assert 'status' in result
+        # 1 data field + status = 2
+        assert len(result) == 2


### PR DESCRIPTION
This PR adds support for PC-series pressure controllers and P-series pressure meters.

This presumably has some scope overlap with #96 and will likely have to be rewritten in part after #96 is merged.

I have tested this with a PC-series pressure controller, but I do not have access to a P-series device to test that the hardware does behave as expected from the description in the Alicat docs.